### PR TITLE
feat: Add dark and light theme support with color and image extensions

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:sadio_mane_store/core/theme/colors/app_dark_theme_colors.dart';
+import 'package:sadio_mane_store/core/theme/colors/app_light_theme_colors.dart';
+import 'package:sadio_mane_store/core/theme/images/app_dark_mode_images.dart';
+import 'package:sadio_mane_store/core/theme/images/app_light_mode_images.dart';
+
+final ThemeData lightTheme = ThemeData(
+  useMaterial3: true,
+  brightness: Brightness.light,
+  extensions: [
+    AppLightModeColors.lightAppColors,
+    AppLightModeImages.lightAppImages,
+  ],
+);
+
+final ThemeData darkTheme =ThemeData(
+  useMaterial3: true,
+  brightness: Brightness.dark,
+extensions: [
+  AppDarkModeColors.darkAppColors,
+  AppDarkModeImages.darkAppImages,
+]
+);

--- a/lib/core/theme/colors/app_dark_theme_colors.dart
+++ b/lib/core/theme/colors/app_dark_theme_colors.dart
@@ -1,0 +1,8 @@
+import 'dart:ui';
+
+import 'package:sadio_mane_store/core/theme/extensions/app_colors_extenstion.dart';
+
+class AppDarkModeColors {
+  static const Color primaryColor = Color(0xffffffff);
+  static final darkAppColors = AppColorsExtension(primaryColor: primaryColor);
+}

--- a/lib/core/theme/colors/app_light_theme_colors.dart
+++ b/lib/core/theme/colors/app_light_theme_colors.dart
@@ -1,0 +1,10 @@
+import 'dart:ui';
+
+import 'package:sadio_mane_store/core/theme/extensions/app_colors_extenstion.dart';
+
+class AppLightModeColors {
+  static const Color primaryColor = Color(0xff6200ee);
+  static final lightAppColors = AppColorsExtension(
+    primaryColor: primaryColor,
+  );
+}

--- a/lib/core/theme/extensions/app_colors_extenstion.dart
+++ b/lib/core/theme/extensions/app_colors_extenstion.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
+  AppColorsExtension({required this.primaryColor});
+
+  final Color primaryColor;
+  @override
+  ThemeExtension<AppColorsExtension> copyWith({Color? primaryColor}) {
+    return AppColorsExtension(primaryColor: primaryColor ?? this.primaryColor);
+  }
+
+  @override
+  ThemeExtension<AppColorsExtension> lerp(
+    covariant ThemeExtension<AppColorsExtension>? other,
+    double t,
+  ) {
+    if (other is! AppColorsExtension) {
+      return this;
+    }
+
+    return AppColorsExtension(
+      primaryColor: Color.lerp(primaryColor, other.primaryColor, t)!,
+    );
+  }
+}

--- a/lib/core/theme/extensions/app_images_extensions.dart
+++ b/lib/core/theme/extensions/app_images_extensions.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class AppImageExtensions extends ThemeExtension<AppImageExtensions> {
+  AppImageExtensions({required this.primaryImage});
+
+  final String primaryImage;
+  @override
+  ThemeExtension<AppImageExtensions> copyWith({String? primaryImage}) {
+    return AppImageExtensions(primaryImage: primaryImage ?? this.primaryImage);
+  }
+
+  @override
+  AppImageExtensions lerp(
+    covariant ThemeExtension<AppImageExtensions>? other,
+    double t,
+  ) {
+    if (other is! AppImageExtensions) return this;
+    return this;
+  }
+}

--- a/lib/core/theme/extensions/app_theme_extension.dart
+++ b/lib/core/theme/extensions/app_theme_extension.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:sadio_mane_store/core/theme/colors/app_light_theme_colors.dart';
+import 'package:sadio_mane_store/core/theme/extensions/app_colors_extenstion.dart';
+import 'package:sadio_mane_store/core/theme/extensions/app_images_extensions.dart';
+import 'package:sadio_mane_store/core/theme/images/app_light_mode_images.dart';
+
+extension AppThemeExtension on ThemeData {
+  AppColorsExtension get appColors =>
+      extension<AppColorsExtension>() ?? AppLightModeColors.lightAppColors;
+  AppImageExtensions get appImage =>
+      extension<AppImageExtensions>() ?? AppLightModeImages.lightAppImages;
+}
+
+extension ThemeGetter on BuildContext {
+  ThemeData get theme => Theme.of(this);
+}

--- a/lib/core/theme/images/app_dark_mode_images.dart
+++ b/lib/core/theme/images/app_dark_mode_images.dart
@@ -1,0 +1,6 @@
+import 'package:sadio_mane_store/core/theme/extensions/app_images_extensions.dart';
+
+class AppDarkModeImages {
+  static const String primaryImage = 'assets/images/png/empty_screen.png';
+  static final darkAppImages = AppImageExtensions(primaryImage: primaryImage);
+}

--- a/lib/core/theme/images/app_light_mode_images.dart
+++ b/lib/core/theme/images/app_light_mode_images.dart
@@ -1,0 +1,7 @@
+import 'package:sadio_mane_store/core/theme/extensions/app_images_extensions.dart';
+
+class AppLightModeImages {
+  static const String primaryImage =
+      'assets/images/png/andriod_12_splash_screen.png';
+ static final lightAppImages = AppImageExtensions(primaryImage: primaryImage);
+}

--- a/lib/sadio_mane_app.dart
+++ b/lib/sadio_mane_app.dart
@@ -8,6 +8,8 @@ import 'package:sadio_mane_store/core/internet_connection/cubit/internet_connect
 import 'package:sadio_mane_store/core/internet_connection/screen/no_internet_screen.dart';
 import 'package:sadio_mane_store/core/routes/app_routes.dart';
 import 'package:sadio_mane_store/core/routes/routes_string.dart';
+import 'package:sadio_mane_store/core/theme/app_theme.dart';
+import 'package:sadio_mane_store/core/theme/extensions/app_theme_extension.dart';
 import 'package:sadio_mane_store/core/theme/font_weight_helper.dart';
 
 class SadioManeApp extends StatelessWidget {
@@ -26,6 +28,7 @@ class SadioManeApp extends StatelessWidget {
         minTextAdapt: true,
         splitScreenMode: true,
         child: MaterialApp(
+          theme: darkTheme,
           onGenerateRoute: AppRoutes.generateRoute,
 
           debugShowCheckedModeBanner: EnvVariable.getInstance.isDev,
@@ -38,12 +41,14 @@ class SadioManeApp extends StatelessWidget {
                       child: Column(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
+                          Image.asset(context.theme.appImage.primaryImage),
                           Text(
                             'Sadio Mane',
                             style: TextStyle(
                               fontFamily: FontsString.poppins,
                               fontWeight: FontWeightHelper.regular,
                               fontSize: 50,
+                              color: context.theme.appColors.primaryColor,
                             ),
                           ),
                           Text(
@@ -52,6 +57,7 @@ class SadioManeApp extends StatelessWidget {
                               fontFamily: FontsString.cairo,
                               fontWeight: FontWeightHelper.medium,
                               fontSize: 50,
+                              color: context.theme.appColors.primaryColor,
                             ),
                           ),
                           MaterialButton(


### PR DESCRIPTION
- App Theme ✅

---
- **Image From Iphone 16 pro max  (Dark Mode)**
![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-21 at 21 00 40](https://github.com/user-attachments/assets/c11ea0fa-9cdd-4c5f-ae6c-5027d7764924)
---
- **Image From Iphone 16 pro max  (Light Mode)**

![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-21 at 21 00 49](https://github.com/user-attachments/assets/ff6478d4-b7b0-43f7-acbc-21e11a5b33c8)
